### PR TITLE
Add bidgear-syndication.com

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202005040831
-! Title: ABPVN List [Add rule from isseu #55]
-! Last modified: 04 May 2020 08:31 UTC+7
+! Version: 202005051419
+! Title: ABPVN List [Add bidgear-syndication.com]
+! Last modified: 05 May 2020 14:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -413,6 +413,7 @@ $webrtc,domain=phim14.net|phimotv.net|appvn.com
 ||bam.nr-data.net
 ||banner.5giay.vn^
 ||bbtrf.info^
+||bidgear-syndication.com^
 ||binomo.com^$popup,third-party
 ||blueseed.tv^$third-party
 ||brand.ad^
@@ -766,8 +767,8 @@ khophimle.com,khoaitv.org,hatde.tv##div[class^="ads-fix-bottom"]
 kiemhieptruyen.com##a[href^="https://shorten.asia"]
 kiemhieptruyen.com#?#p.hoi:-abp-contains(DEAL)
 kiemhieptruyen.com#?#p:-abp-has(a[href^="http://bit.ly"])
-kienthuc.net.vn##.sponsor-zone
 kienthuc.net.vn##.sponsor-zone + div
+kienthuc.net.vn##.sponsor-zone
 kphim.tv##.ads-insider
 kphim.tv##.right-movie-info
 kqxs.vn##.bggradient-mien

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202005040831
-! Title: ABPVN List [Add rule from isseu #55]
-! Last modified: 04 May 2020 08:31 UTC+7
+! Version: 202005051419
+! Title: ABPVN List [Add bidgear-syndication.com]
+! Last modified: 05 May 2020 14:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -413,6 +413,7 @@ $webrtc,domain=phim14.net|phimotv.net|appvn.com
 ||bam.nr-data.net
 ||banner.5giay.vn^
 ||bbtrf.info^
+||bidgear-syndication.com^
 ||binomo.com^$popup,third-party
 ||blueseed.tv^$third-party
 ||brand.ad^

--- a/filter/src/abpvn_ad_domain.txt
+++ b/filter/src/abpvn_ad_domain.txt
@@ -46,6 +46,7 @@
 ||bam.nr-data.net
 ||banner.5giay.vn^
 ||bbtrf.info^
+||bidgear-syndication.com^
 ||binomo.com^$popup,third-party
 ||blueseed.tv^$third-party
 ||brand.ad^

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -266,8 +266,8 @@ khophimle.com,khoaitv.org,hatde.tv##div[class^="ads-fix-bottom"]
 kiemhieptruyen.com##a[href^="https://shorten.asia"]
 kiemhieptruyen.com#?#p.hoi:-abp-contains(DEAL)
 kiemhieptruyen.com#?#p:-abp-has(a[href^="http://bit.ly"])
-kienthuc.net.vn##.sponsor-zone
 kienthuc.net.vn##.sponsor-zone + div
+kienthuc.net.vn##.sponsor-zone
 kphim.tv##.ads-insider
 kphim.tv##.right-movie-info
 kqxs.vn##.bggradient-mien

--- a/filter/src/abpvn_title.txt
+++ b/filter/src/abpvn_title.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Version: _version_
-! Title: ABPVN List [Add rule from isseu #55]
+! Title: ABPVN List [Add bidgear-syndication.com]
 ! Last modified: _time_stamp_ UTC+7
 ! Expires: 1 days (update frequency)
 !


### PR DESCRIPTION
Đoạn script chứa quảng cáo
```
https://bidgear-syndication.com/hd-adx?hid=270&t=1587627817&k=5ea14729d6c8a
https://vegacdn1.bidgear-syndication.com/hb/i3.js
```

Script sẽ dẫn quảng cáo đến địa chỉ
```
https://securepubads.g.doubleclick.net/tag/js/gpt.js
​https://5734a40f2d.vws.vegacdn.vn/hb/prebid2.35.0.20191010.1.js
```

Rất nhiều trang báo sử dụng tên miền quảng cáo này
```
https://yeah1.com/
https://thanhnien.vn/
```

Mình đề nghị thêm cả tên miền quảng cáo này vào bộ lọc để chặn ở tất cả các trang có chứa script tương tự này!