### PR TITLE
fix tinhte.vn

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181330
-! Title: ABPVN List [gocmod.com]
-! Last modified: 18 Aug 2020 13:30 UTC+7
+! Version: 202008181350
+! Title: ABPVN List [fix tinhte.vn]
+! Last modified: 18 Aug 2020 13:50 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -750,8 +750,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper
@@ -1210,6 +1210,7 @@ zingnews.vn,vnexpress.net,ngoisao.net###banner_top
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 !--------Element Hiding Exception--------------
 @@||1shortlink.com$generichide
 @@||ani4u.org$generichide

--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181350
+! Version: 202008181358
 ! Title: ABPVN List [fix tinhte.vn]
-! Last modified: 18 Aug 2020 13:50 UTC+7
+! Last modified: 18 Aug 2020 13:58 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1195,6 +1195,7 @@ zingnews.vn,vnexpress.net,ngoisao.net###banner_top
 @@||etoy.vn/upload/product/$image,~third-party
 @@||game24h.vn/js/ads_$script,~third-party
 @@||gateway.chotot.com^$xmlhttprequest,domain=chotot.com
+@@||gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 @@||htv3tv.com/ads1/mobile.js
 @@||iamcdn.net/players/ads.js
 @@||iamcdn.net/players/app.ads.js
@@ -1210,7 +1211,6 @@ zingnews.vn,vnexpress.net,ngoisao.net###banner_top
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
-@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 !--------Element Hiding Exception--------------
 @@||1shortlink.com$generichide
 @@||ani4u.org$generichide

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181350
+! Version: 202008181358
 ! Title: ABPVN List [fix tinhte.vn]
-! Last modified: 18 Aug 2020 13:50 UTC+7
+! Last modified: 18 Aug 2020 13:58 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -583,6 +583,7 @@ a3manga.com##div[id$="-catfish"]
 @@||etoy.vn/upload/product/$image,~third-party
 @@||game24h.vn/js/ads_$script,~third-party
 @@||gateway.chotot.com^$xmlhttprequest,domain=chotot.com
+@@||gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 @@||htv3tv.com/ads1/mobile.js
 @@||iamcdn.net/players/ads.js
 @@||iamcdn.net/players/app.ads.js
@@ -598,7 +599,6 @@ a3manga.com##div[id$="-catfish"]
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
-@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 !------ ABPVN Adult block -------
 $popup,domain=hentailxx.com|hoihentai.com
 /plugins/vast-$script

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181330
-! Title: ABPVN List [gocmod.com]
-! Last modified: 18 Aug 2020 13:30 UTC+7
+! Version: 202008181350
+! Title: ABPVN List [fix tinhte.vn]
+! Last modified: 18 Aug 2020 13:50 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -598,6 +598,7 @@ a3manga.com##div[id$="-catfish"]
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 !------ ABPVN Adult block -------
 $popup,domain=hentailxx.com|hoihentai.com
 /plugins/vast-$script

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -195,8 +195,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper

--- a/filter/src/abpvn_title.txt
+++ b/filter/src/abpvn_title.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Version: _version_
-! Title: ABPVN List [gocmod.com]
+! Title: ABPVN List [fix tinhte.vn]
 ! Last modified: _time_stamp_ UTC+7
 ! Expires: 1 days (update frequency)
 !

--- a/filter/src/abpvn_whitelist.txt
+++ b/filter/src/abpvn_whitelist.txt
@@ -28,6 +28,7 @@
 @@||etoy.vn/upload/product/$image,~third-party
 @@||game24h.vn/js/ads_$script,~third-party
 @@||gateway.chotot.com^$xmlhttprequest,domain=chotot.com
+@@||gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
 @@||htv3tv.com/ads1/mobile.js
 @@||iamcdn.net/players/ads.js
 @@||iamcdn.net/players/app.ads.js
@@ -43,4 +44,3 @@
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
-@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn

--- a/filter/src/abpvn_whitelist.txt
+++ b/filter/src/abpvn_whitelist.txt
@@ -43,3 +43,4 @@
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||www.gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn


### PR DESCRIPTION
Rule `/firebase-analytics.js` trong bộ lọc `EasyPrivacy` gây lỗi không load được trang `https://tinhte.vn/fact/`

URL ảnh hưởng: 

```
https://www.gstatic.com/firebasejs/7.5.2/firebase-analytics.js
```

Rule đề xuất thêm (bỏ www)

```
@@||gstatic.com/firebasejs/*/firebase-analytics.js$script,domain=tinhte.vn
```

Ảnh

![Screenshot_2020-08-18 undefined Tinh tế](https://user-images.githubusercontent.com/10969626/90480363-53f39500-e15a-11ea-9773-91c1772a19d3.png)
