### PR TITLE
fix vietnamplus.vn

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181330
-! Title: ABPVN List [gocmod.com]
-! Last modified: 18 Aug 2020 13:30 UTC+7
+! Version: 202008181612
+! Title: ABPVN List [vietnamplus.vn elemhide]
+! Last modified: 18 Aug 2020 16:12 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -750,8 +750,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper
@@ -1110,6 +1110,7 @@ vietjack.com##.block-teasers-47483
 vietjack.com##div[id^="ads_"]
 vietnamgsm.vn###headerProxy
 vietnamnet.vn##.fmsidWidgetNewsBox
+vietnamplus.vn##.ads.banner
 vietyo.com###bar_top_r
 vinaurl.com,vinaurl.in#?#.alert-danger:-abp-has(a[href])
 violympic.vn##._3wPJb

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008181330
-! Title: ABPVN List [gocmod.com]
-! Last modified: 18 Aug 2020 13:30 UTC+7
+! Version: 202008181612
+! Title: ABPVN List [vietnamplus.vn elemhide]
+! Last modified: 18 Aug 2020 16:12 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -195,8 +195,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper
@@ -555,6 +555,7 @@ vietjack.com##.block-teasers-47483
 vietjack.com##div[id^="ads_"]
 vietnamgsm.vn###headerProxy
 vietnamnet.vn##.fmsidWidgetNewsBox
+vietnamplus.vn##.ads.banner
 vietyo.com###bar_top_r
 vinaurl.com,vinaurl.in#?#.alert-danger:-abp-has(a[href])
 violympic.vn##._3wPJb

--- a/filter/src/abpvn_title.txt
+++ b/filter/src/abpvn_title.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Version: _version_
-! Title: ABPVN List [gocmod.com]
+! Title: ABPVN List [vietnamplus.vn elemhide]
 ! Last modified: _time_stamp_ UTC+7
 ! Expires: 1 days (update frequency)
 !


### PR DESCRIPTION
Các phần tử được tìm thấy trong trang web

```
vietnamplus.vn###adsmainContent_AdsHome21471739048.ads.banner
vietnamplus.vn###adsmainContent_AdsHome51471739048.ads.banner
vietnamplus.vn###adsmainContent_AdsHome31471739048.ads.banner
vietnamplus.vn###adsmainContent_AdsHome61471739048.ads.banner
```

Các phần tử này có phần số thay đổi ngẫu nhiên, tuy nhiên đoạn `.ads.banner` đều giống nhau nên mình đều xuất rule chặn

```
vietnamplus.vn##.ads.banner
```

Ảnh

![Screenshot (72)](https://user-images.githubusercontent.com/10969626/90495136-75f71280-e16e-11ea-9f2d-7fb2ab43929e.png)
