### PR TITLE
Update viettelstore.vn

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008260828
-! Title: ABPVN List [hhkungfu.tv]
-! Last modified: 26 Aug 2020 08:28 UTC+7
+! Version: 202008261557
+! Title: ABPVN List [update viettelstore.vn]
+! Last modified: 26 Aug 2020 15:57 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -755,8 +755,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper
@@ -1133,6 +1133,8 @@ vietnamnet.vn##.fmsidWidgetNewsBox
 vietnamnet.vn##.VnnAdsPos
 vietnamplus.vn###rubrikk
 vietnamplus.vn##.zone--ad
+viettelstore.vn###banner-dai-bottom
+viettelstore.vn###banner-dai-top
 vietyo.com###bar_top_r
 vinaurl.com#?#.alert-danger:-abp-has(a[href])
 violympic.vn##._3wPJb
@@ -1242,6 +1244,7 @@ zingnews.vn,vnexpress.net,ngoisao.net###banner_top
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||viettelstore.vn/images/Advertises/*$image
 !--------Element Hiding Exception--------------
 @@||1shortlink.com$generichide
 @@||ani4u.org$generichide

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202008260828
-! Title: ABPVN List [hhkungfu.tv]
-! Last modified: 26 Aug 2020 08:28 UTC+7
+! Version: 202008261557
+! Title: ABPVN List [update viettelstore.vn]
+! Last modified: 26 Aug 2020 15:57 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -604,6 +604,7 @@ a3manga.com##div[id$="-catfish"]
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||viettelstore.vn/images/Advertises/*$image
 !------ ABPVN Adult block -------
 $popup,domain=hentailxx.com|hoihentai.com|viet69.co
 /plugins/vast-$script

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -197,8 +197,8 @@ datviet.com##.wpadverts-widget-categories
 datviet.com##.wpadverts-widget-recent
 datviet.com,anonyviet.com##.widget_custom_html
 designs.vn##.qc-right2
-dethihocki.com##.detail_new + p
 dethihocki.com##.detail_new + p + table
+dethihocki.com##.detail_new + p
 diendanxaydung.vn###header_adcode
 diendanxaydung.vn###rightcolumn_adcode
 dongphym.net,dongphym.com##.vast-checkpoint-wrapper
@@ -575,6 +575,8 @@ vietnamnet.vn##.fmsidWidgetNewsBox
 vietnamnet.vn##.VnnAdsPos
 vietnamplus.vn###rubrikk
 vietnamplus.vn##.zone--ad
+viettelstore.vn###banner-dai-bottom
+viettelstore.vn###banner-dai-top
 vietyo.com###bar_top_r
 vinaurl.com#?#.alert-danger:-abp-has(a[href])
 violympic.vn##._3wPJb

--- a/filter/src/abpvn_title.txt
+++ b/filter/src/abpvn_title.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Version: _version_
-! Title: ABPVN List [hhkungfu.tv]
+! Title: ABPVN List [update viettelstore.vn]
 ! Last modified: _time_stamp_ UTC+7
 ! Expires: 1 days (update frequency)
 !

--- a/filter/src/abpvn_whitelist.txt
+++ b/filter/src/abpvn_whitelist.txt
@@ -46,3 +46,4 @@
 @@||truyentranhtuan.com/manga1/$image
 @@||tvhayz.org/ads/125buon.php
 @@||vatlypt.com/ad/banner/$xmlhttprequest,~third-party
+@@||viettelstore.vn/images/Advertises/*$image


### PR DESCRIPTION
Rule `/advertises/*` của `EasyList` không load được hình ở trang chủ, các link bị ảnh hưởng

```
https://cdn2.viettelstore.vn/images/Advertises/Note20-Ultra_20tr_main_2_74126101126082020.jpg
https://cdn2.viettelstore.vn/images/Advertises/hp_gocphai_5230190904082020.jpg
https://cdn2.viettelstore.vn/images/Advertises/realmec12._mainpc_53454361925082020.jpg
...
```

![Screenshot_2020-08-26 Viettel Store - Nhà mạng bán điện thoại lớn nhất Việt Nam](https://user-images.githubusercontent.com/10969626/91283977-85e9a480-e7b5-11ea-91b6-8453648c5ff0.png)

Đề xuất rule bỏ qua, để trang chủ hiển thị đầy đủ

```
@@||viettelstore.vn/images/Advertises/*$image
```

Đề xuất chặn 2 banner đầu và dưới ở trang chủ là đủ

```
viettelstore.vn###banner-dai-top
viettelstore.vn###banner-dai-bottom
```
