### PR TITLE
fix banner gdt.gov.vn

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202107291430
-! Title: ABPVN List [optimize filter]
-! Last modified: 29 Jul 2021 14:30 UTC+7
+! Version: 202107292128
+! Title: ABPVN List [fix banner gdt.gov.vn]
+! Last modified: 29 Jul 2021 21:28 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1630,12 +1630,14 @@ zphimmoi.tv,zone.tv##.uniad-zonetype-preload-container
 @@||tainhanhvn.com$generichide
 @@||traderviet.com$generichide
 @@||vtvgiaitri.vn$generichide
+canhan.gdt.gov.vn#@#.banner
 duytan.edu.vn#@##adbox
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@##ad-banner
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@#.ad-banner
 pops.vn#@##adsContainer
 pops.vn#@#.ad-placement
 sum.vn#@#.adsbygoogle
+thuedientu.gdt.gov.vn#@#.banner
 tratu.soha.vn#@#.adheader
 truyenaudiocv.net#@#.ads-large
 vtvgiaitri.vn#@#.pub_300x250

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202107291430
-! Title: ABPVN List [optimize filter]
-! Last modified: 29 Jul 2021 14:30 UTC+7
+! Version: 202107292128
+! Title: ABPVN List [fix banner gdt.gov.vn]
+! Last modified: 29 Jul 2021 21:28 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202107291430
-! Title: ABPVN List [optimize filter]
-! Last modified: 29 Jul 2021 14:30 UTC+7
+! Version: 202107292128
+! Title: ABPVN List [fix banner gdt.gov.vn]
+! Last modified: 29 Jul 2021 21:28 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1630,12 +1630,14 @@ zphimmoi.tv,zone.tv##.uniad-zonetype-preload-container
 @@||tainhanhvn.com$generichide
 @@||traderviet.com$generichide
 @@||vtvgiaitri.vn$generichide
+canhan.gdt.gov.vn#@#.banner
 duytan.edu.vn#@##adbox
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@##ad-banner
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@#.ad-banner
 pops.vn#@##adsContainer
 pops.vn#@#.ad-placement
 sum.vn#@#.adsbygoogle
+thuedientu.gdt.gov.vn#@#.banner
 tratu.soha.vn#@#.adheader
 truyenaudiocv.net#@#.ads-large
 vtvgiaitri.vn#@#.pub_300x250

--- a/filter/src/abpvn_title.txt
+++ b/filter/src/abpvn_title.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Version: _version_
-! Title: ABPVN List [optimize filter]
+! Title: ABPVN List [fix banner gdt.gov.vn]
 ! Last modified: _time_stamp_ UTC+7
 ! Expires: 1 days (update frequency)
 !

--- a/filter/src/abpvn_whitelist_elemhide.txt
+++ b/filter/src/abpvn_whitelist_elemhide.txt
@@ -10,12 +10,14 @@
 @@||tainhanhvn.com$generichide
 @@||traderviet.com$generichide
 @@||vtvgiaitri.vn$generichide
+canhan.gdt.gov.vn#@#.banner
 duytan.edu.vn#@##adbox
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@##ad-banner
 linkviet.xyz,linkvietvip.com,megalink.vip,linkcc.pro,link1s.com#@#.ad-banner
 pops.vn#@##adsContainer
 pops.vn#@#.ad-placement
 sum.vn#@#.adsbygoogle
+thuedientu.gdt.gov.vn#@#.banner
 tratu.soha.vn#@#.adheader
 truyenaudiocv.net#@#.ads-large
 vtvgiaitri.vn#@#.pub_300x250


### PR DESCRIPTION
Rule mới cập nhật gần đây `.banner` (commit https://github.com/abpvn/abpvn/commit/81da32abe83c9cb5759d71fa6e4281b9eeb211ac) ảnh hưởng đến banner trên cùng của trang khai và nộp thuế của Tổng cục Thuế có nút đăng nhập và đăng ký

Rule đề xuất loại trừ

```
thuedientu.gdt.gov.vn#@#.banner
canhan.gdt.gov.vn#@#.banner
```

Ảnh chụp

![Untitled](https://user-images.githubusercontent.com/10969626/127510708-b7708412-2faa-49d5-ab45-d0d6e496e354.png)
![Untitled2](https://user-images.githubusercontent.com/10969626/127510741-de0d4829-cb3c-4db1-aac4-9978f7f951e0.png)
