### PR TITLE
background của ads

### DIFF
--- a/filter/src/abpvn_general.txt
+++ b/filter/src/abpvn_general.txt
@@ -180,6 +180,7 @@ utm_source=propellerads$popup
 ||datcang.vn/images/khicon.jpg
 ||dc.mpapis.xyz/*.gif$image
 ||delivery.yeah1media.vn^
+||delivery.adsterra.org/publisher/bg.preload.jpg
 ||depmoingay.net.vn/banner
 ||dexuat.com^*banner$image
 ||diendanlequydon.com/banner/


### PR DESCRIPTION
Quảng cáo của adsterra sẽ có một background mặc dù khi chặn quảng cáo vẫn có một lớp đen mờ phía sau.