### PR TITLE
M: techrum.vn

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112180939
+! Version: 202112191023
 ! Title: ABPVN List
-! Last modified: 18 Dec 2021 09:39 UTC+7
+! Last modified: 19 Dec 2021 10:23 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1438,9 +1438,9 @@ subnhanh.net##.banner-sticky-footer-ad
 tapchikientruc.com.vn##._ning_outer
 techrum.vn##.k_ads_vip_2
 techrum.vn##.vip_ad_div
-techrum.vn##div.block:nth-of-type(5)
-techrum.vn##div.block:nth-of-type(6)
-techrum.vn##div.block:nth-of-type(7)
+techrum.vn##body[data-template="forum_list"] > .p-body > .p-body-inner > .p-breadcrumbs--container
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > a[href])
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > ins)
 thanhnien.vn##div[id^="dablewidget_"]
 thanhtra.com.vn###Adsv
 thatlangon.com##[class*="thatl-in-article"]

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112180939
+! Version: 202112191023
 ! Title: ABPVN List
-! Last modified: 18 Dec 2021 09:39 UTC+7
+! Last modified: 19 Dec 2021 10:23 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1438,9 +1438,9 @@ subnhanh.net##.banner-sticky-footer-ad
 tapchikientruc.com.vn##._ning_outer
 techrum.vn##.k_ads_vip_2
 techrum.vn##.vip_ad_div
-techrum.vn##div.block:nth-of-type(5)
-techrum.vn##div.block:nth-of-type(6)
-techrum.vn##div.block:nth-of-type(7)
+techrum.vn##body[data-template="forum_list"] > .p-body > .p-body-inner > .p-breadcrumbs--container
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > a[href])
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > ins)
 thanhnien.vn##div[id^="dablewidget_"]
 thanhtra.com.vn###Adsv
 thatlangon.com##[class*="thatl-in-article"]

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112180939
+! Version: 202112191023
 ! Title: ABPVN List
-! Last modified: 18 Dec 2021 09:39 UTC+7
+! Last modified: 19 Dec 2021 10:23 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112180939
+! Version: 202112191023
 ! Title: ABPVN List
-! Last modified: 18 Dec 2021 09:39 UTC+7
+! Last modified: 19 Dec 2021 10:23 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1438,9 +1438,9 @@ subnhanh.net##.banner-sticky-footer-ad
 tapchikientruc.com.vn##._ning_outer
 techrum.vn##.k_ads_vip_2
 techrum.vn##.vip_ad_div
-techrum.vn##div.block:nth-of-type(5)
-techrum.vn##div.block:nth-of-type(6)
-techrum.vn##div.block:nth-of-type(7)
+techrum.vn##body[data-template="forum_list"] > .p-body > .p-body-inner > .p-breadcrumbs--container
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > a[href])
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > ins)
 thanhnien.vn##div[id^="dablewidget_"]
 thanhtra.com.vn###Adsv
 thatlangon.com##[class*="thatl-in-article"]

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -584,9 +584,9 @@ subnhanh.net##.banner-sticky-footer-ad
 tapchikientruc.com.vn##._ning_outer
 techrum.vn##.k_ads_vip_2
 techrum.vn##.vip_ad_div
-techrum.vn##div.block:nth-of-type(5)
-techrum.vn##div.block:nth-of-type(6)
-techrum.vn##div.block:nth-of-type(7)
+techrum.vn##body[data-template="forum_list"] > .p-body > .p-body-inner > .p-breadcrumbs--container
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > a[href])
+techrum.vn#?#.block:-abp-has(> .block-container > .block-body > ins)
 thanhnien.vn##div[id^="dablewidget_"]
 thanhtra.com.vn###Adsv
 thatlangon.com##[class*="thatl-in-article"]


### PR DESCRIPTION
I think the `nth-of-type` filters cause some incorrect blocks in `techrum.vn`. It blocks `Nhiều người xem` section and some other sections in `forums` path. Other advertisement sections like `Quảng cáo`, `Có thể bạn quan tâm` or `bit.ly` banners are not blocked.

URL:
`https://www.techrum.vn/`
`https://www.techrum.vn/forums/`

<details><summary>Homepage screenshot</summary>

![image](https://user-images.githubusercontent.com/66517106/146661588-75e7ca7d-aee6-4ee3-926d-ceba12b35711.png)

</details>

<details><summary>Forum screenshot</summary>

![image](https://user-images.githubusercontent.com/66517106/146661603-64336473-9a99-4412-a8f2-a78c5c3fe2dd.png)

</details>

Firefox 95.0.1, ublock 1.39.2 EasyList + ABPVN