### PR TITLE
Update baomoi.com, thuthuatjb.com, bongda365.tv

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191521
+! Version: 202112191522
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:21 UTC+7
+! Last modified: 19 Dec 2021 15:22 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1467,6 +1467,7 @@ thoibaotaichinhvietnam.vn##.tab-qc
 thoidai.com.vn,petrotimes.vn##.__ads_click
 thuongtruong.com.vn###BannerAdv
 thuongtruong.com.vn##.bannercenter
+thuthuatjb.com##.stream-item
 thuthuattienich.com###footer-widget-area
 thuthuattienich.com##.e3lan.e3lan-top
 thuysanvietnam.com.vn###gallery-2

--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191023
+! Version: 202112191521
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 10:23 UTC+7
+! Last modified: 19 Dec 2021 15:21 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -952,7 +952,8 @@ baobinhthuan.com.vn###ads_2_col_bot
 baodauthau.vn##.advertise
 baodauthau.vn##.main-ad-wrapper
 baohaugiang.com.vn##.top-header
-baomoi.com##.bm_JO
+baomoi.com###BaoMoi_HalfPage
+baomoi.com#?##__next > div:-abp-has(#BaoMoi_Masthead)
 baonga.com##.monkey-content-duoicanbiet
 baonga.com##.monkey-section-tinnoibat
 baonga.com##div.monkey-qc

--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191522
+! Version: 202112191524
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:22 UTC+7
+! Last modified: 19 Dec 2021 15:24 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -975,6 +975,7 @@ blogtruyen.vn##div.qc_TC_Chap_Middle
 blogtruyen.vn##div[id^="qc_M_"]
 bongda.com.vn###onefootball
 bongda.com.vn##.top_page
+bongda365.tv##a[href*="dafabet"]
 bongdahomnay.org,bongdahomnay.tech##.btn-green
 bongdahomnay.org,bongdahomnay.tech##.head-bet-btn
 bongdahomnay.org,bongdahomnay.tech##.pr-box

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191521
+! Version: 202112191522
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:21 UTC+7
+! Last modified: 19 Dec 2021 15:22 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1467,6 +1467,7 @@ thoibaotaichinhvietnam.vn##.tab-qc
 thoidai.com.vn,petrotimes.vn##.__ads_click
 thuongtruong.com.vn###BannerAdv
 thuongtruong.com.vn##.bannercenter
+thuthuatjb.com##.stream-item
 thuthuattienich.com###footer-widget-area
 thuthuattienich.com##.e3lan.e3lan-top
 thuysanvietnam.com.vn###gallery-2

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191023
+! Version: 202112191521
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 10:23 UTC+7
+! Last modified: 19 Dec 2021 15:21 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -952,7 +952,8 @@ baobinhthuan.com.vn###ads_2_col_bot
 baodauthau.vn##.advertise
 baodauthau.vn##.main-ad-wrapper
 baohaugiang.com.vn##.top-header
-baomoi.com##.bm_JO
+baomoi.com###BaoMoi_HalfPage
+baomoi.com#?##__next > div:-abp-has(#BaoMoi_Masthead)
 baonga.com##.monkey-content-duoicanbiet
 baonga.com##.monkey-section-tinnoibat
 baonga.com##div.monkey-qc

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191522
+! Version: 202112191524
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:22 UTC+7
+! Last modified: 19 Dec 2021 15:24 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -975,6 +975,7 @@ blogtruyen.vn##div.qc_TC_Chap_Middle
 blogtruyen.vn##div[id^="qc_M_"]
 bongda.com.vn###onefootball
 bongda.com.vn##.top_page
+bongda365.tv##a[href*="dafabet"]
 bongdahomnay.org,bongdahomnay.tech##.btn-green
 bongdahomnay.org,bongdahomnay.tech##.head-bet-btn
 bongdahomnay.org,bongdahomnay.tech##.pr-box

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191521
+! Version: 202112191522
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:21 UTC+7
+! Last modified: 19 Dec 2021 15:22 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191023
+! Version: 202112191521
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 10:23 UTC+7
+! Last modified: 19 Dec 2021 15:21 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191522
+! Version: 202112191524
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:22 UTC+7
+! Last modified: 19 Dec 2021 15:24 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191521
+! Version: 202112191522
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:21 UTC+7
+! Last modified: 19 Dec 2021 15:22 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -1467,6 +1467,7 @@ thoibaotaichinhvietnam.vn##.tab-qc
 thoidai.com.vn,petrotimes.vn##.__ads_click
 thuongtruong.com.vn###BannerAdv
 thuongtruong.com.vn##.bannercenter
+thuthuatjb.com##.stream-item
 thuthuattienich.com###footer-widget-area
 thuthuattienich.com##.e3lan.e3lan-top
 thuysanvietnam.com.vn###gallery-2

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191023
+! Version: 202112191521
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 10:23 UTC+7
+! Last modified: 19 Dec 2021 15:21 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -952,7 +952,8 @@ baobinhthuan.com.vn###ads_2_col_bot
 baodauthau.vn##.advertise
 baodauthau.vn##.main-ad-wrapper
 baohaugiang.com.vn##.top-header
-baomoi.com##.bm_JO
+baomoi.com###BaoMoi_HalfPage
+baomoi.com#?##__next > div:-abp-has(#BaoMoi_Masthead)
 baonga.com##.monkey-content-duoicanbiet
 baonga.com##.monkey-section-tinnoibat
 baonga.com##div.monkey-qc

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112191522
+! Version: 202112191524
 ! Title: ABPVN List
-! Last modified: 19 Dec 2021 15:22 UTC+7
+! Last modified: 19 Dec 2021 15:24 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -975,6 +975,7 @@ blogtruyen.vn##div.qc_TC_Chap_Middle
 blogtruyen.vn##div[id^="qc_M_"]
 bongda.com.vn###onefootball
 bongda.com.vn##.top_page
+bongda365.tv##a[href*="dafabet"]
 bongdahomnay.org,bongdahomnay.tech##.btn-green
 bongdahomnay.org,bongdahomnay.tech##.head-bet-btn
 bongdahomnay.org,bongdahomnay.tech##.pr-box

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -613,6 +613,7 @@ thoibaotaichinhvietnam.vn##.tab-qc
 thoidai.com.vn,petrotimes.vn##.__ads_click
 thuongtruong.com.vn###BannerAdv
 thuongtruong.com.vn##.bannercenter
+thuthuatjb.com##.stream-item
 thuthuattienich.com###footer-widget-area
 thuthuattienich.com##.e3lan.e3lan-top
 thuysanvietnam.com.vn###gallery-2

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -121,6 +121,7 @@ blogtruyen.vn##div.qc_TC_Chap_Middle
 blogtruyen.vn##div[id^="qc_M_"]
 bongda.com.vn###onefootball
 bongda.com.vn##.top_page
+bongda365.tv##a[href*="dafabet"]
 bongdahomnay.org,bongdahomnay.tech##.btn-green
 bongdahomnay.org,bongdahomnay.tech##.head-bet-btn
 bongdahomnay.org,bongdahomnay.tech##.pr-box

--- a/filter/src/abpvn_elemhide.txt
+++ b/filter/src/abpvn_elemhide.txt
@@ -98,7 +98,8 @@ baobinhthuan.com.vn###ads_2_col_bot
 baodauthau.vn##.advertise
 baodauthau.vn##.main-ad-wrapper
 baohaugiang.com.vn##.top-header
-baomoi.com##.bm_JO
+baomoi.com###BaoMoi_HalfPage
+baomoi.com#?##__next > div:-abp-has(#BaoMoi_Masthead)
 baonga.com##.monkey-content-duoicanbiet
 baonga.com##.monkey-section-tinnoibat
 baonga.com##div.monkey-qc


### PR DESCRIPTION
### baomoi.com

Placeholder at the top changes the class name over time, previous is `bm_JO`, now is `bm_JQ`

URL: 
https://baomoi.com/

<details><summary>Screenshot</summary>

![baomoi](https://user-images.githubusercontent.com/66517106/146668616-a5212877-595f-4387-a515-e32aaffef387.png)

</details>

-----------------------

### thuthuatjb.com

Placeholder.

URL:
[https://thuthuatjb.com/](https://thuthuatjb.com/)

<details><summary>Screenshot</summary>

![jb](https://user-images.githubusercontent.com/66517106/146668637-a7525b5f-4886-4f02-a453-9a0039afe072.png)

</details>

-----------------------

### bongda365.tv

Ads banner

URL:
https://bongda365.tv/

<details><summary>Screenshot</summary>

![365](https://user-images.githubusercontent.com/66517106/146668649-b045634d-2902-46d7-a165-593a17e753ac.png)

</details>

Firefox 95.0.1, ublock 1.39.2 EasyList + ABPVN