### PR TITLE
Incorrect block in earthcam.com

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112251821
+! Version: 202112261240
 ! Title: ABPVN List
-! Last modified: 25 Dec 2021 18:21 UTC+7
+! Last modified: 26 Dec 2021 12:40 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -60,7 +60,7 @@ $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|bil
 /uploads/wangcao/*
 /vast.$script,xmlhttprequest,domain=~ynet.co.il|~xemvtv.net|~nhaccuatui.com|~supjav.com
 /vast\d+\./$xmlhttprequest
-/videojs.ima.js$domain=~jut.su
+/videojs.ima.js$domain=~jut.su|~earthcam.com
 /zone.uniad.vn/$image
 clbgamesvn.com##.bannerBox
 clbgamesvn.com##.footerBanner

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112251821
+! Version: 202112261240
 ! Title: ABPVN List
-! Last modified: 25 Dec 2021 18:21 UTC+7
+! Last modified: 26 Dec 2021 12:40 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -60,7 +60,7 @@ $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|bil
 /uploads/wangcao/*
 /vast.$script,xmlhttprequest,domain=~ynet.co.il|~xemvtv.net|~nhaccuatui.com|~supjav.com
 /vast\d+\./$xmlhttprequest
-/videojs.ima.js$domain=~jut.su
+/videojs.ima.js$domain=~jut.su|~earthcam.com
 /zone.uniad.vn/$image
 clbgamesvn.com##.bannerBox
 clbgamesvn.com##.footerBanner

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112251821
+! Version: 202112261240
 ! Title: ABPVN List
-! Last modified: 25 Dec 2021 18:21 UTC+7
+! Last modified: 26 Dec 2021 12:40 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -60,7 +60,7 @@ $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|bil
 /uploads/wangcao/*
 /vast.$script,xmlhttprequest,domain=~ynet.co.il|~xemvtv.net|~nhaccuatui.com|~supjav.com
 /vast\d+\./$xmlhttprequest
-/videojs.ima.js$domain=~jut.su
+/videojs.ima.js$domain=~jut.su|~earthcam.com
 /zone.uniad.vn/$image
 clbgamesvn.com##.bannerBox
 clbgamesvn.com##.footerBanner

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202112251821
+! Version: 202112261240
 ! Title: ABPVN List
-! Last modified: 25 Dec 2021 18:21 UTC+7
+! Last modified: 26 Dec 2021 12:40 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -60,7 +60,7 @@ $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|bil
 /uploads/wangcao/*
 /vast.$script,xmlhttprequest,domain=~ynet.co.il|~xemvtv.net|~nhaccuatui.com|~supjav.com
 /vast\d+\./$xmlhttprequest
-/videojs.ima.js$domain=~jut.su
+/videojs.ima.js$domain=~jut.su|~earthcam.com
 /zone.uniad.vn/$image
 clbgamesvn.com##.bannerBox
 clbgamesvn.com##.footerBanner

--- a/filter/src/abpvn_general.txt
+++ b/filter/src/abpvn_general.txt
@@ -44,7 +44,7 @@ $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|bil
 /uploads/wangcao/*
 /vast.$script,xmlhttprequest,domain=~ynet.co.il|~xemvtv.net|~nhaccuatui.com|~supjav.com
 /vast\d+\./$xmlhttprequest
-/videojs.ima.js$domain=~jut.su
+/videojs.ima.js$domain=~jut.su|~earthcam.com
 /zone.uniad.vn/$image
 clbgamesvn.com##.bannerBox
 clbgamesvn.com##.footerBanner


### PR DESCRIPTION
Incorrect block causes video player not able to play, due to the filter:
`/videojs.ima.js$domain=~jut.su`

URL:
`https://www.earthcam.com/usa/newyork/timessquare/?cam=tsstreet`

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/66517106/147399987-972b03c9-d1a1-4001-a003-aa54679924d0.png)

</details>

Firefox 95.0.2, ublock 1.40.0 EasyList + ABPVN