### PR TITLE
D: noudescor.com, fidlarmusic.com

### DIFF
--- a/filter/abpvn.txt
+++ b/filter/abpvn.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202201230940
+! Version: 202201231919
 ! Title: ABPVN List
-! Last modified: 23 Jan 2022 09:40 UTC+7
+! Last modified: 23 Jan 2022 19:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -16,7 +16,7 @@
 ! Report new issue on github: https://github.com/abpvn/abpvn/issues/new
 ! ---------- Generic Blocking Rules ----------
 $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|biluu.co|animehay.site|hhkungfu.tv|fancoiphim.net
-*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
+*$csp=script-src 'self' 'unsafe-inline',domain=kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
 .com/cpc/$script
 .com/qc/
 .net/ads/$domain=~linkneverdie.net

--- a/filter/abpvn_adguard.txt
+++ b/filter/abpvn_adguard.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202201230940
+! Version: 202201231919
 ! Title: ABPVN List
-! Last modified: 23 Jan 2022 09:40 UTC+7
+! Last modified: 23 Jan 2022 19:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -16,7 +16,7 @@
 ! Report new issue on github: https://github.com/abpvn/abpvn/issues/new
 ! ---------- Generic Blocking Rules ----------
 $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|biluu.co|animehay.site|hhkungfu.tv|fancoiphim.net
-*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
+*$csp=script-src 'self' 'unsafe-inline',domain=kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
 .com/cpc/$script
 .com/qc/
 .net/ads/$domain=~linkneverdie.net

--- a/filter/abpvn_noelemhide.txt
+++ b/filter/abpvn_noelemhide.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202201230940
+! Version: 202201231919
 ! Title: ABPVN List
-! Last modified: 23 Jan 2022 09:40 UTC+7
+! Last modified: 23 Jan 2022 19:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -16,7 +16,7 @@
 ! Report new issue on github: https://github.com/abpvn/abpvn/issues/new
 ! ---------- Generic Blocking Rules ----------
 $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|biluu.co|animehay.site|hhkungfu.tv|fancoiphim.net
-*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
+*$csp=script-src 'self' 'unsafe-inline',domain=kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
 .com/cpc/$script
 .com/qc/
 .net/ads/$domain=~linkneverdie.net

--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
-! Version: 202201230940
+! Version: 202201231919
 ! Title: ABPVN List
-! Last modified: 23 Jan 2022 09:40 UTC+7
+! Last modified: 23 Jan 2022 19:19 UTC+7
 ! Expires: 1 days (update frequency)
 !
 ! ABPVN List filter
@@ -16,7 +16,7 @@
 ! Report new issue on github: https://github.com/abpvn/abpvn/issues/new
 ! ---------- Generic Blocking Rules ----------
 $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|biluu.co|animehay.site|hhkungfu.tv|fancoiphim.net
-*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
+*$csp=script-src 'self' 'unsafe-inline',domain=kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
 .com/cpc/$script
 .com/qc/
 .net/ads/$domain=~linkneverdie.net

--- a/filter/src/abpvn_general.txt
+++ b/filter/src/abpvn_general.txt
@@ -1,6 +1,6 @@
 ! ---------- Generic Blocking Rules ----------
 $popup,third-party,domain=megaurl.in|hamtruyen.com|phim1080z.com|fim1080.com|biluu.co|animehay.site|hhkungfu.tv|fancoiphim.net
-*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
+*$csp=script-src 'self' 'unsafe-inline',domain=kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
 .com/cpc/$script
 .com/qc/
 .net/ads/$domain=~linkneverdie.net


### PR DESCRIPTION
Adblock is detected with links redirected from `link1s` when enabling ABPVN.

URL:
[https://link1s.net/1lbLR](https://link1s.net/1lbLR)

You might need to reload the site many times, since it redirects to multiple domains randomly. When it redirects to `nousdecor.com` and `fidlarmusic.com`, an anti-adblock appears due to this filter:
```
*$csp=script-src 'self' 'unsafe-inline',domain=nousdecor.com|fidlarmusic.com|kingsleynyc.com|thegoneapp.com|staaker.com|uebnews.online|nro.vn|appvn.com|kiemlua.com|kynangso.net|dhcc.uk
```

- `noudescor.com`

<details><summary>ABPVN enabled</summary>

![nou_i](https://user-images.githubusercontent.com/66517106/150677905-10286cdd-0d50-4d79-9a33-fcb1ed6bb48c.png)

</details>

<details><summary>ABPVN disabled</summary>

![nou](https://user-images.githubusercontent.com/66517106/150677919-2cbc63b0-a609-48bd-9274-4b6449a5289b.png)

</details>

- `fidlarmusic.com`

<details><summary>ABPVN enabled</summary>

![fid_i](https://user-images.githubusercontent.com/66517106/150677935-8b85c324-6b5b-4eef-8acc-46b9395e3c15.png)

</details>

<details><summary>ABPVN disabled</summary>

![fid](https://user-images.githubusercontent.com/66517106/150677961-20a9783a-b659-42dc-8b6a-ee18ebdcd29b.png)

</details>

Firefox 96.0.2, ublock 1.40.8 default settings (9 default filter lists).