### PR TITLE
A: realclick.vn, aiservice.vn

### DIFF
--- a/filter/src/abpvn_ad_domain.txt
+++ b/filter/src/abpvn_ad_domain.txt
@@ -111,6 +111,7 @@
 ||qc.violet.vn^
 ||qccoccocmedia.vn^
 ||qcv5.blogtruyen.vn^
+||realclick.vn^$third-party
 ||s1block.com^$third-party
 ||santruongit.com^$popup,third-party
 ||sartorsstagne.com^

--- a/filter/src/abpvn_ad_domain.txt
+++ b/filter/src/abpvn_ad_domain.txt
@@ -17,6 +17,7 @@
 ||adtop.vn^$third-party
 ||aff.opus-static.com^$third-party
 ||affiliate.k4.tinhte.vn^
+||aiservice.vn^$third-party
 ||aj1047.online^
 ||aj2393.online^
 ||amcdn.vn^


### PR DESCRIPTION
Targeted example:
- realclick.vn
  - https://quantrimang.com/total-cookie-protection-mozilla-firefox-190658
- aiservice.vn
  - https://genk.vn/
  - https://cafef.vn/
  - https://cafebiz.vn/

AFAIK `aiservice.vn` isn't an ads publisher. It's a tracking service. _Should there be a separate list for trackers instead, e.g. `abpvn_tracking_domain.txt`?_ It may help future maintenance when this list grows. E.g. EasyList for ads, EasyPrivacy for tracker.