### PR TITLE
truyenqqko.com ad leftovers + annoyance

### DIFF
--- a/filter/abpvn_ublock.txt
+++ b/filter/abpvn_ublock.txt
@@ -716,6 +716,8 @@ truyenqqko.com###floating-banner-left
 truyenqqko.com###floating-banner-right
 truyenqqko.com##.text_ads
 truyenqqko.com##div#ad_info
+truyenqqko.com##div[id^="_pop-qqgo-"]
+truyenqqko.com##span:has-text(/Quảng cáo/)
 truyenqqko.com,foxtruyen2.com###ad_info_top
 truyensieuhay.com##.footer-info
 truyensieuhay.com,hhtrungquoc9.com,hhtq13.vip,hhtq3d.net###topbanner


### PR DESCRIPTION
They fix the following: https://github.com/uBlockOrigin/uAssets/issues/34151

and also these ad leftovers:

<img width="1736" height="822" alt="image" src="https://github.com/user-attachments/assets/f3b11d0e-e7ca-4d42-9c76-588dbe7597c6" />
